### PR TITLE
Fix exception error on new Laravel version

### DIFF
--- a/src/ProfanityFilterServiceProvider.php
+++ b/src/ProfanityFilterServiceProvider.php
@@ -24,7 +24,7 @@ class ProfanityFilterServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['profanity'] = $this->app->share(function($app) {
+        $this->app->singleton('profanity', function($app) {
             $dependency = $this->app['config']['profanity-filter.words'];
             $blacklist  = $this->app['config']['profanity-filter.blacklist'];
             $replace    = $this->app['config']['profanity-filter.replace'];


### PR DESCRIPTION
Fix 'Call to undefined method Illuminate\Foundation\Application::share()' exception error on newer version of Laravel